### PR TITLE
feat: add read receipts events

### DIFF
--- a/src/handlers/chat.ts
+++ b/src/handlers/chat.ts
@@ -47,6 +47,17 @@ export function chatHandler(socket: Socket<ClientToServerEvents, ServerToClientE
         }
     });
 
+    socket.on(ClientEvents.READ_MESSAGE, ({ messageId }) => {
+        const partnerId = chatService.getPartnerId(socket.id);
+        if (partnerId) {
+          socket.to(partnerId).emit(ServerEvents.MARK_AS_READ, {
+            messageId
+          });
+        } else {
+          socket.emit(ServerEvents.ERROR, { message: 'No partner found.' });
+        }
+    });
+
     socket.on(ClientEvents.DISCONNECT_PARTNER, () => {
         const partnerId = chatService.disconnectPartner(socket.id);
         if (partnerId) {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -4,6 +4,7 @@ export enum ClientEvents {
     INIT_USER = 'init_user',
     FIND_PARTNER = 'find_partner',
     SEND_MESSAGE = 'send_message',
+    READ_MESSAGE = 'read_message',
     DISCONNECT_PARTNER = 'disconnect_partner'
 }
 
@@ -11,6 +12,7 @@ export enum ServerEvents {
     WAITING = 'waiting',
     MATCHED = 'matched',
     RECEIVE_MESSAGE = 'receive_message',
+    MARK_AS_READ = 'mark_as_read',
     PARTNER_DISCONNECTED = 'partner_disconnected',
     ERROR = 'error'
 }
@@ -19,6 +21,7 @@ export interface ClientToServerEvents {
     [ClientEvents.INIT_USER]: (data: { name: string }) => void;
     [ClientEvents.FIND_PARTNER]: () => void;
     [ClientEvents.SEND_MESSAGE]: (data: { message: string|null, image: string|null }) => void;
+    [ClientEvents.READ_MESSAGE]: (data: { messageId: number }) => void;
     [ClientEvents.DISCONNECT_PARTNER]: () => void;
 }
 
@@ -26,6 +29,7 @@ export interface ServerToClientEvents {
     [ServerEvents.WAITING]: () => void;
     [ServerEvents.MATCHED]: (data: { partnerName: string }) => void;
     [ServerEvents.RECEIVE_MESSAGE]: (data: Message) => void;
+    [ServerEvents.MARK_AS_READ]: (data: {messageId: number}) => void;
     [ServerEvents.PARTNER_DISCONNECTED]: () => void;
     [ServerEvents.ERROR]: (data: { message: string }) => void;
 }


### PR DESCRIPTION
This is the backend implementation to add the functionaility to show whether the receiver has received and read the sender's messages or not. 